### PR TITLE
fix: missing BrowserModule.withServerTransition

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,9 @@ export class AppComponent {}
 
 @NgModule({
 	imports: [
-		BrowserModule,
+		BrowserModule.withServerTransition({
+		  appId: 'universal-demo-app'
+		}),
 		RouterModule.forRoot([
 			{ path: '', component: HomeView, pathMatch: 'full'},
 			{ path: 'lazy', loadChildren: './lazy.module#LazyModule'}


### PR DESCRIPTION
Without this, angular throws a helpful error while serving the page:

```bash
Unhandled Promise rejection: renderModule[Factory]() requires the use of BrowserModule.withServerTransition() to ensure
the server-rendered app can be properly bootstrapped into a client app. ; Zone: <root> ; Task: Promise.then ; Value: { Error: renderModule[Factory]() requires the use of BrowserModule.withServerTransition() to ensure
the server-rendered app can be properly bootstrapped into a client app.
    at new Error (native)
    at Error.v (/Users/coolpath/ng-universal-demo/dist/main.js:251:2215)
    at /Users/coolpath/ng-universal-demo/dist/main.js:155:16564
    at e.invoke (/Users/coolpath/ng-universal-demo/dist/main.js:251:8988)
    at n.run (/Users/coolpath/ng-universal-demo/dist/main.js:251:4723)
    at /Users/coolpath/ng-universal-demo/dist/main.js:251:1787
    at e.invokeTask (/Users/coolpath/ng-universal-demo/dist/main.js:251:9672)
    at n.runTask (/Users/coolpath/ng-universal-demo/dist/main.js:251:5372)
    at o (/Users/coolpath/ng-universal-demo/dist/main.js:251:499)
    at Server.invoke (/Users/coolpath/ng-universal-demo/dist/main.js:251:10588)
    at emitTwo (events.js:106:13)
    at Server.emit (events.js:191:7)
    at HTTPParser.parserOnIncoming [as onIncoming] (_http_server.js:546:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:99:23)
...
```